### PR TITLE
Add support for SSM versioned parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ User can put AWS Parameter Store ARN as environment variable value. The `secrets
 ```sh
 # environment variable passed to `secrets-init`
 MY_API_KEY=arn:aws:ssm:$AWS_REGION:$AWS_ACCOUNT_ID:parameter/api/key
+# OR versioned parameter
+MY_API_KEY=arn:aws:ssm:$AWS_REGION:$AWS_ACCOUNT_ID:parameter/api/key:$VERSION
 
 # environment variable passed to child process, resolved by `secrets-init`
 MY_API_KEY=key-123456789

--- a/pkg/secrets/aws/secrets.go
+++ b/pkg/secrets/aws/secrets.go
@@ -54,9 +54,15 @@ func (sp *SecretsProvider) ResolveSecrets(ctx context.Context, vars []string) ([
 		} else if strings.HasPrefix(value, "arn:aws:ssm") && strings.Contains(value, ":parameter/") {
 			tokens := strings.Split(value, ":")
 			// valid parameter ARN arn:aws:ssm:REGION:ACCOUNT:parameter/PATH
-			if len(tokens) == 6 {
+			// or arn:aws:ssm:REGION:ACCOUNT:parameter/PATH:VERSION
+			if len(tokens) == 6 || len(tokens) == 7 {
 				// get SSM parameter name (path)
 				paramName := strings.TrimPrefix(tokens[5], "parameter")
+
+				if len(tokens) == 7 {
+					paramName = strings.Join([]string{paramName, tokens[6]}, ":")
+				}
+
 				// get AWS SSM API
 				withDecryption := true
 				param, err := sp.ssm.GetParameter(&ssm.GetParameterInput{


### PR DESCRIPTION
SSM allows querying arbitrary versions of parameters. This feature will help when you want to do a rolling deployment on new parameter version.