### PR TITLE
Don't use a nil provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,11 +145,16 @@ func run(ctx context.Context, provider secrets.Provider, commandSlice []string) 
 	// create a dedicated pidgroup used to forward signals to the main process and its children
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// set environment variables
 	var err error
-	cmd.Env, err = provider.ResolveSecrets(ctx, os.Environ())
-	if err != nil {
-		log.WithError(err).Error("failed to resolve secrets")
+	// set environment variables
+	if provider != nil {
+		cmd.Env, err = provider.ResolveSecrets(ctx, os.Environ())
+		if err != nil {
+			log.WithError(err).Error("failed to resolve secrets")
+		}
+	} else {
+		log.Warn("no secrets provider available; using environment without resolving secrets")
+		cmd.Env = os.Environ()
 	}
 
 	// start the specified command


### PR DESCRIPTION
If the secrets provider fails to initialize, an error is logged and
the initialization returns nil. Later, ResolveSecrets would be called
on the resulting nil provider, causing a segfault.

This adds a safer fallback that skips the ResolveSecrets call on a nil
provider, instead passing along the environment unchanged without
resolving secrets. An additional warning is logged when this happens.

This way failure to initialize a secret provider won't completely stop
the container from running.