### PR TITLE
add support for fetching values from key/value secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-FROM alpine:3.10
+FROM golang:1.15-alpine as builder
 
-ADD secrets-init /usr/local/bin/secrets-init
+WORKDIR /app
+COPY . .
+
+RUN go mod download
+RUN go build -o /app/secrets-init
+# ADD secrets-init /usr/local/bin/secrets-init
+
+FROM alpine:latest
+COPY --from=builder /app/secrets-init /usr/local/bin/secrets-init
 
 CMD ["secrets-init", "--version"]

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
+	github.com/tidwall/gjson v1.7.4
 	github.com/urfave/cli/v2 v2.0.0
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d
 	google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,12 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tidwall/gjson v1.7.4 h1:19cchw8FOxkG5mdLRkGf9jqIqEyqdZhPqW60XfyFxk8=
+github.com/tidwall/gjson v1.7.4/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/urfave/cli/v2 v2.0.0 h1:+HU9SCbu8GnEUFtIBfuUNXN39ofWViIEJIp6SURMpCg=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Currently this repo only supports a single plaintext secret to be fetched. This PR allows you to specify the same ARN with a `#KEY` to fetch only the value from that key. This was inspired from previously using https://github.com/banzaicloud/bank-vaults/tree/master/charts/vault-secrets-webhook

```
- name: PGPASSWORD
  value: arn:aws:secretsmanager:us-west-2:<account_id>:secret:my-database-secret#DB_PASSWORD
- name: PGUSER
  value: arn:aws:secretsmanager:us-west-2:<account_id>:secret:my-database-secret#DB_USER

```

EDIT:
Testing this requires adding 2 flags to `kube-secrets-init` command
```
- --image=yourrepo/this-image:latest
- --pull-policy=Always
```