### PR TITLE
remove WNOHANG

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func removeZombies(childPid int) {
 		var status syscall.WaitStatus
 
 		// wait for an orphaned zombie process
-		pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+		pid, err := syscall.Wait4(-1, &status, 0, nil)
 
 		if pid == -1 {
 			// if errno == ECHILD then no children remain; exit cleanly


### PR DESCRIPTION
This causes it to wait for a child to exit instead of running in a busy loop. This was intended to be in 
https://github.com/doitintl/secrets-init/pull/14 as seen in the discussion here https://github.com/doitintl/secrets-init/pull/14#discussion_r732456649 but I inadvertently removed it in a later commit.