### PR TITLE
feat: add log format flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,13 @@ var (
 
 func main() {
 	app := &cli.App{
+		Before: setLogFormatter,
 		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "log-format, l",
+				Usage: "select logrus formatter ['json', 'text']",
+				Value: "text",
+			},
 			&cli.StringFlag{
 				Name:  "provider, p",
 				Usage: "supported secrets manager provider ['aws', 'google']",
@@ -235,4 +241,13 @@ func run(ctx context.Context, provider secrets.Provider, commandSlice []string) 
 	}()
 
 	return childPid, err
+}
+
+func setLogFormatter(c *cli.Context) error {
+	if c.String("log-format") == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	} else if c.String("log-format") == "text" {
+		log.SetFormatter(&log.TextFormatter{})
+	}
+	return nil
 }


### PR DESCRIPTION
Addresses https://github.com/doitintl/secrets-init/issues/10

Adds a simple cli flag `-log-format`, default to the current formatter for logrus (text), but add an option allowing a switch to the [JSONFormatter](https://github.com/sirupsen/logrus#formatters). Runs in the `Before` initializer to ensure the option is applied to all logs (https://github.com/urfave/cli/blob/master/docs/v2/manual.md)

See it in action:
```
➜  secrets-init git:(feature/json-logging) go build
➜  secrets-init git:(feature/json-logging) ✗ ./secrets-init
WARN[0000] no command specified
➜  secrets-init git:(feature/json-logging) ✗ ./secrets-init --log-format json
{"level":"warning","msg":"no command specified","time":"2022-03-25T14:25:58-04:00"}
```