### PR TITLE
feat: add env var to log flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,9 +39,10 @@ func main() {
 		Before: setLogFormatter,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "log-format, l",
-				Usage: "select logrus formatter ['json', 'text']",
-				Value: "text",
+				Name:    "log-format, l",
+				Usage:   "select logrus formatter ['json', 'text']",
+				Value:   "text",
+				EnvVars: []string{"LOG_FORMAT"},
 			},
 			&cli.StringFlag{
 				Name:  "provider, p",


### PR DESCRIPTION
Quick followup - add the ability to set the logging via env var as well. Allows for a bit smoother deployments changes without having to modify charts/upstream chains of deps. A run through all the varieties of logging possibilities:

![image](https://user-images.githubusercontent.com/885563/199519352-34fc4a0b-5b32-4510-99f9-fd279ae7e14b.png)
