### PR TITLE
Do not forward SIGURG to the child process

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,8 +230,12 @@ func run(ctx context.Context, provider secrets.Provider, commandSlice []string) 
 	// Goroutine for signals forwarding
 	go func() {
 		for sig := range sigs {
-			// ignore SIGCHLD signals since these are only useful for secrets-init
-			if sig != syscall.SIGCHLD {
+			// ignore:
+			// - SIGCHLD signals, since these are only useful for secrets-init
+			// - SIGURG signals, since they are used internally by the secrets-init
+			//   go runtime (see https://github.com/golang/go/issues/37942) and are of
+			//   no interest to the child process
+			if sig != syscall.SIGCHLD && sig != syscall.SIGURG {
 				// forward signal to the main process and its children
 				e := syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
 				if e != nil {


### PR DESCRIPTION
Since go 1.14, SIGURG is emitted internally by the fo runtime, see:

- https://github.com/golang/[go/issues/37942](https://www.golinks.io/issues/37942?trackSource=github)
- https://go.googlesource.com/proposal/+/master/design/24543-non-cooperative-preemption.md#other-considerations "Choosing a signal"

This causes two problems:
- This will interfere with processes that use SIGURG for a real purpose (though this is unlikely)
- If SIGURG is emitted after the child process has exited but before secrets-init, there will be a spurious error message (see #16)
