### PR TITLE
Add environment variable for all flags and envvar prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,21 +42,23 @@ func main() {
 				Name:    "log-format, l",
 				Usage:   "select logrus formatter ['json', 'text']",
 				Value:   "text",
-				EnvVars: []string{"LOG_FORMAT"},
+				EnvVars: []string{"SECRETS_INIT_LOG_FORMAT", "LOG_FORMAT"},
 			},
 			&cli.StringFlag{
 				Name:  "provider, p",
 				Usage: "supported secrets manager provider ['aws', 'google']",
 				Value: "aws",
+				EnvVars: []string{"SECRETS_INIT_SECRETS_PROVIDER"}
 			},
 			&cli.BoolFlag{
 				Name:    "exit-early",
 				Usage:   "exit when a provider fails or a secret is not found",
-				EnvVars: []string{"EXIT_EARLY"},
+				EnvVars: []string{"SECRETS_INIT_EXIT_EARLY", "EXIT_EARLY"},
 			},
 			&cli.StringFlag{
 				Name:  "google-project",
 				Usage: "the google cloud project for secrets without a project prefix",
+				EnvVars: []string{"SECRETS_INIT_GOOGLE_PROJECT"}
 			},
 		},
 		Commands: []*cli.Command{

--- a/main.go
+++ b/main.go
@@ -45,10 +45,10 @@ func main() {
 				EnvVars: []string{"SECRETS_INIT_LOG_FORMAT", "LOG_FORMAT"},
 			},
 			&cli.StringFlag{
-				Name:  "provider, p",
-				Usage: "supported secrets manager provider ['aws', 'google']",
-				Value: "aws",
-				EnvVars: []string{"SECRETS_INIT_SECRETS_PROVIDER"}
+				Name:    "provider, p",
+				Usage:   "supported secrets manager provider ['aws', 'google']",
+				Value:   "aws",
+				EnvVars: []string{"SECRETS_INIT_SECRETS_PROVIDER", "SECRETS_PROVIDER"},
 			},
 			&cli.BoolFlag{
 				Name:    "exit-early",
@@ -56,9 +56,9 @@ func main() {
 				EnvVars: []string{"SECRETS_INIT_EXIT_EARLY", "EXIT_EARLY"},
 			},
 			&cli.StringFlag{
-				Name:  "google-project",
-				Usage: "the google cloud project for secrets without a project prefix",
-				EnvVars: []string{"SECRETS_INIT_GOOGLE_PROJECT"}
+				Name:    "google-project",
+				Usage:   "the google cloud project for secrets without a project prefix",
+				EnvVars: []string{"SECRETS_INIT_GOOGLE_PROJECT", "GOOGLE_PROJECT"},
 			},
 		},
 		Commands: []*cli.Command{


### PR DESCRIPTION
## What

- Add environment variable for `provider` flag
- Add environment variable for `google-project` flag
- Add optional environment variables format with `SECRETS_INIT` prefix

## Why

- Using secrets init for apps in GCP required setting the command line flag rather than the much easier (in kubernetes at least) environment variable flow
- Using a prefix for environment variables helps to avoid collision (in particular with `LOG_FORMAT`)