### PR TITLE
Interactive mode in interpreter sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,8 @@ FROM busybox:1.36
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/app/.bin/secrets-init /secrets-init
+RUN adduser -D -u 1000 secrets-init
+USER 1000
+
 ENTRYPOINT ["/secrets-init"]
 CMD ["--version"]

--- a/main.go
+++ b/main.go
@@ -58,6 +58,11 @@ func main() {
 				Name:  "google-project",
 				Usage: "the google cloud project for secrets without a project prefix",
 			},
+			&cli.BoolFlag{
+				Name:  "interactive",
+				Aliases: []string{"i"},
+				Usage: "use this flag if the command expects some input from the stdin",
+			},
 		},
 		Commands: []*cli.Command{
 			{
@@ -149,7 +154,7 @@ func mainCmd(c *cli.Context) error {
 
 	// Launch main command
 	var childPid int
-	childPid, err = run(ctx, provider, c.Bool("exit-early"), c.Args().Slice())
+	childPid, err = run(ctx, provider, c.Bool("exit-early"), c.Bool("interactive"), c.Args().Slice())
 	if err != nil {
 		log.WithError(err).Error("failed to run")
 		os.Exit(1)
@@ -188,7 +193,7 @@ func removeZombies(childPid int) {
 }
 
 // run passed command
-func run(ctx context.Context, provider secrets.Provider, exitEarly bool, commandSlice []string) (childPid int, err error) {
+func run(ctx context.Context, provider secrets.Provider, exitEarly, interactive bool, commandSlice []string) (childPid int, err error) {
 	var commandStr string
 	var argsSlice []string
 
@@ -212,8 +217,13 @@ func run(ctx context.Context, provider secrets.Provider, exitEarly bool, command
 	cmd := exec.Command(commandStr, argsSlice...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	// create a dedicated pidgroup used to forward signals to the main process and its children
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// rebind stdin if -i flag is set
+	if interactive {
+		cmd.Stdin = os.Stdin
+	} else {
+		// create a dedicated pidgroup used to forward signals to the main process and its children
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 
 	// set environment variables
 	if provider != nil {


### PR DESCRIPTION
## Problem description

`secrets-init` cannot be used in scenarios when you need to `kubectl exec -i -t <pod-name> -- /bin/sh|python3` into a pod and run commands that require Secrets Manager secrets (say you want to query a DB and you need the credentials). That is because `secrets-init` is launching a new process with a dedicated process group for it and only sets stdout and stderr of the process to the "calling" process (you can see the logs/errors). Since `stdin` is not connected, the process exits immediately after the process is started.
When you exec into the pod, it would be nice to use secrets-init to fetch the secrets and keep the terminal console open.

## Current behaviour

Say there is a running pod called `terminal` in the `default` namespace, running `python3` image, with an env var configured:
```
- name: GSM_SECRET
  value: aws/gcp-sm-secret-ref
```
From local machine, running `kubectl exec -i -t terminal -- python3`, the command opens the python interpreter but secret env vars are not populated.

Running `kubectl exec -i -t terminal -- secrets-init --provider <aws/gcp> python3` exits without any exit code/reason.

## Desired behaviour

Running `kubectl exec -i -t terminal -- secrets-init --provider <aws/gcp> python3`, it would be nice to connect to the python console process and run python commands. Running
```
import os
os.environ['GSM_SECRET']
```
should return the "secret" value obtained by `secrets-init` from the cloud secrets manager.

## Proposed solution

This PR adds a new command line argument to `secrets-init` (`--interactive`/`-i`) which will bind the launched process stdin to the "calling" process stdin.

~~### However...~~

~~The changes present in this pr are changes that worked for us (meaning that we can run `secrets-init` in interactive mode and do stuff), however, there are two problems:~~
1. ~~The process fails to treat window size change events. We see this error: `ERRO[0000] failed to send system signal to the process   args="[python3]" error="no such process" path=/usr/local/bin/python3 pid=93 signal=SIGWINCH`~~
2. ~~The only way we managed to keep the interpreter console opened is by not switching to another GPID. And this in my opinion is breaking one of the core functions of `secrets-init` to be an init system.~~

I would like to receive some feedback from anyone who has any idea on how to fix the above issues and get this change merged.

## Update 8th of May

I managed to fix the issue with the `SIGWINCH` signal by setting the new process to run in foreground. So, in interactive mode, the only changes to the process config are:
* bind stdin
* set process to run in foreground

Tested this configuration on Google Kubernetes Engine `v1.27.11-gke.1062001` using `kube-secrets-init:0.5.0` and `secrets-init` works well. In non-interactive mode, the behaviour is the same, so backwards compatibility is not an issue. Opening a shell in the pod (`kubectl -n <ns> exec -it secret-init-terminal-test -- /helper/bin/secrets-init -i --provider=google python3`).

Additionally, I updated the Dockerfile to run the container under a non root user.

